### PR TITLE
Updated turnkey-version.py for Python 2/3 compatibility

### DIFF
--- a/turnkey-version.py
+++ b/turnkey-version.py
@@ -1,52 +1,54 @@
-#!/usr/bin/python
+#! /usr/bin/python
 # Ad-hoc version detection for a system installed from a TurnKey
 # appliance. This is a transitory package so we can identify the versions
 # in current appliance which were designed before we needed this for
 # tklbam. In the future it shouldn't be needed as all appliances will be
 # marked with their versions.
 
+from __future__ import print_function
+from builtins import str
 from os.path import join
 
 import sys
 
 def usage(e=None):
     if e:
-        print >> sys.stderr, "error: " + str(e)
+        print(u'error: ' + str(e), file=sys.stderr)
 
-    print >> sys.stderr, "Syntax: %s [rootfs]" % sys.argv[0]
+    print(u"Syntax: %s [rootfs]" % sys.argv[0], file=sys.stderr)
     sys.exit(1)
 
 class Error(Exception):
     pass
 
 def fatal(s):
-    print >> sys.stderr, "error: " + str(s)
+    print(u'error: ' + str(s), file=sys.stderr)
     sys.exit(1)
 
 def get_turnkey_version(rootfs):
     try:
-        return file(join(rootfs, "etc/turnkey_version")).read().strip()
+        return open(join(rootfs, u'etc/turnkey_version')).read().strip()
     except IOError:
-	    raise Error("can't detect turnkey version - missing /etc/turnkey_version file")
+        raise Error(u'can\'t detect turnkey version - missing /etc/turnkey_version file')
 
 def main():
     args = sys.argv[1:]
 
-    rootfs = "/"
+    rootfs = u'/'
     if args:
         if args[0] in ('-h', '--help'):
             usage()
 
         if len(args) != 1:
-            usage("incorrect number of arguments")
+            usage(u'incorrect number of arguments')
 
         rootfs = args[0]
 
     try:
-        print get_turnkey_version(rootfs)
-    except Error, e:
+        print(get_turnkey_version(rootfs))
+    except Error as e:
         fatal(e)
 
-if __name__=="__main__":
+if __name__=='__main__':
     main()
 


### PR DESCRIPTION
As an experiment I tried updating `turnkey-version.py` so it is compatible with both Python2 & Python3 using `futurize` and advice from http://python-future.org/.  I have tested the result against both Python 2.7 and Python 3.5.  I did not test against 2.6 but I suspect that it may no longer be supported.

I did not make any changes to the Debian packaging files.  These will need to be adjusted before building a newer package.  I don't have any experience with Debian package building so I felt it was best left to the package maintainers.

Edit: Using `futurize` creates a dependency on the python module `python-future`. Older jessie appliances v14.2 will need to install `python-future` in order to use this version of `turnkey-version.py`